### PR TITLE
Mention the shortcut key for 'pop-tag-mark.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,5 @@ This package allows emacs to use [Racer](http://github.com/phildawes/racer) for 
 
 6. Place your cursor over a symbol and hit `M-.` to jump to the
 definition.
+
+7. Hit `M-,` to jump back to the symbol usage location.


### PR DESCRIPTION
Add a mention of how to jump back after reading the definition of a symbol.