### PR TITLE
Only use racer for completions in rust-mode.

### DIFF
--- a/racer.el
+++ b/racer.el
@@ -231,7 +231,7 @@ foo(bar, |baz); -> foo|(bar, baz);"
   :lighter " racer"
   :keymap racer-mode-map
   (setq-local eldoc-documentation-function #'racer-eldoc)
-  (make-local-variable 'completion-at-point-functions)
+  (set (make-local-variable 'completion-at-point-functions) nil)
   (add-hook 'completion-at-point-functions #'racer-complete-at-point))
 
 (define-obsolete-function-alias 'racer-turn-on-eldoc 'eldoc-mode)


### PR DESCRIPTION
The default value for `completion-at-point-functions` is
`'(tags-completion-at-point-function)`. As a result, if the user has any
tags tables in `tagsl-table-list` then `company-capf` tries to use those
tags tables for completions.

Instead, we ensure that `completion-at-point-functions` is initialised
to nil, so rust-mode buffers don't end up using these unwanted other
completion sources.

@fbergroth does this look reasonable to you? I'm still learning about CAPF.