### PR TITLE
[duplicated #31] Fix bug if CARGO_HOME is not set

### DIFF
--- a/racer.el
+++ b/racer.el
@@ -79,7 +79,7 @@
   :group 'racer)
 
 (defcustom racer-cargo-home
-  (or (getenv "CARGO_HOME") (concat (getenv "HOME") ".cargo"))
+  (or (getenv "CARGO_HOME") (concat (getenv "HOME") "/.cargo"))
   "To enable completion for cargo crates, you need to set the CARGO_HOME environment variable to .cargo in your home directory."
   :type 'file
   :group 'racer


### PR DESCRIPTION
If CARGO_HOME is not set the default is to concat "$HOME" and ".cargo" which results in "/home/user.cargo" which is obviously not correct.

I don't know much elisp so I may be talking nonsense.

**EDIT: aparently #31 does almost the exact same thing so feel free to close this**