### PR TITLE
Fixed formatting of StructField completions

### DIFF
--- a/racer.el
+++ b/racer.el
@@ -162,6 +162,8 @@
              (if (string= arg ctx)
                  ""
                (concat " " ctx)))
+	    ("StructField"
+	     (concat " " ctx))
             (_
              (->> ctx
                   (racer--trim-up-to arg)


### PR DESCRIPTION
This PR fixes the completion text for StructField completion candidates:

Before:
![alt text](http://i.imgur.com/sjg2u4j.png)

After:
![alt text](http://i.imgur.com/C9OB9sx.png)

