### PR TITLE
Add a racer-describe command.

### DIFF
--- a/racer.el
+++ b/racer.el
@@ -174,8 +174,12 @@ the user to choose."
          (relevant-matches (--filter (equal (plist-get it :name) name)
                                      all-matches)))
     (if (> (length relevant-matches) 1)
-        ;; TODO: use completing-read here.
-        (user-error "multiple matches")
+        ;; We might have multiple matches with the same name but
+        ;; different types. E.g. Vec::from.
+        (let ((signature
+               (completing-read "Multiple matches: "
+                                (--map (plist-get it :signature) relevant-matches))))
+          (--first (equal (plist-get it :signature) signature) relevant-matches))
       (-first-item relevant-matches))))
 
 (defun racer--help-buf (name contents)

--- a/racer.el
+++ b/racer.el
@@ -391,6 +391,7 @@ Commands:
             :annotation-function #'racer-complete--annotation
             :company-prefix-length (racer-complete--prefix-p beg end)
             :company-docsig #'racer-complete--docsig
+            :company-doc-buffer #'racer--describe
             :company-location #'racer-complete--location))))
 
 (defun racer-complete (&optional _ignore)

--- a/racer.el
+++ b/racer.el
@@ -344,11 +344,19 @@ COLUMN number."
          (concat "    " (racer--syntax-highlight (plist-get description :signature)))
          docstring))))))
 
+(defvar racer-help-mode-map
+  (let ((map (make-sparse-keymap)))
+    (set-keymap-parent map (make-composed-keymap button-buffer-map
+                                                 special-mode-map))
+    map)
+  "Keymap for racer help mode.")
+
 (define-derived-mode racer-help-mode fundamental-mode
   "Racer-Help"
-  "Major mode for *Racer Help* buffers.")
+  "Major mode for *Racer Help* buffers.
 
-(define-key racer-help-mode-map (kbd "q") #'kill-this-buffer)
+Commands:
+\\{racer-help-mode-map}")
 
 (defun racer-complete-at-point ()
   "Complete the symbol at point."

--- a/racer.el
+++ b/racer.el
@@ -330,7 +330,7 @@ COLUMN number."
            (docstring (if raw-docstring
                           (racer--propertize-docstring raw-docstring)
                         "Not documented.")))
-      (switch-to-buffer
+      (temp-buffer-window-show
        (racer--help-buf
         name
         (format

--- a/test/racer-test.el
+++ b/test/racer-test.el
@@ -115,7 +115,7 @@ baz.")))
                 "MATCH new;new();294;11;/home/user/src/rustc-1.10.0/src/libstd/../libcollections/vec.rs;Function;pub fn new() -> Vec<T>;\"Constructs a new, empty `Vec<T>`.\""
                 "END"))))
     (should
-     (equal (plist-get (racer--describe-at-point) :name)
+     (equal (plist-get (racer--describe-at-point "new") :name)
             "new"))))
 
 (ert-deftest racer--describe-at-point-nil-docstring ()
@@ -127,7 +127,7 @@ baz.")))
                 "MATCH new;new();294;11;/home/user/src/rustc-1.10.0/src/libstd/../libcollections/vec.rs;Function;pub fn new() -> Vec<T>;\"\""
                 "END"))))
     (should
-     (null (plist-get (racer--describe-at-point) :docstring)))))
+     (null (plist-get (racer--describe-at-point "new") :docstring)))))
 
 (ert-deftest racer--describe-at-point-shortest ()
   "If there are multiple matches, we want the shortest.
@@ -137,11 +137,12 @@ Since we've moved point to the end of symbol, the other functions just happen to
              (lambda (&rest _)
                (list
                 "PREFIX 36,37,n"
+                "MATCH new_bar;new_bar();294;11;/home/user/src/rustc-1.10.0/src/libstd/../libcollections/vec.rs;Function;pub fn new() -> Vec<T>;\"\""
                 "MATCH new;new();294;11;/home/user/src/rustc-1.10.0/src/libstd/../libcollections/vec.rs;Function;pub fn new() -> Vec<T>;\"\""
                 "MATCH new_foo;new_foo();294;11;/home/user/src/rustc-1.10.0/src/libstd/../libcollections/vec.rs;Function;pub fn new() -> Vec<T>;\"\""
                 "END"))))
     (should
-     (equal (plist-get (racer--describe-at-point) :name)
+     (equal (plist-get (racer--describe-at-point "new") :name)
             "new"))))
 
 (ert-deftest racer--syntax-highlight ()
@@ -166,31 +167,13 @@ Since we've moved point to the end of symbol, the other functions just happen to
   "Smoke test for `racer-describe'."
   (cl-letf (((symbol-function 'racer--call)
              (lambda (&rest _)
+               (setq point-during-call (point))
                (list
                 "PREFIX 36,37,n"
-                "MATCH new;new();294;11;/home/user/src/rustc-1.10.0/src/libstd/../libcollections/vec.rs;Function;pub fn new() -> Vec<T>;\"\""
+                "MATCH foo;foo();294;11;/home/user/src/rustc-1.10.0/src/libstd/../libcollections/vec.rs;Function;pub fn new() -> Vec<T>;\"\""
                 "END"))))
-    (racer-describe)))
-
-(ert-deftest racer-describe-uses-whole-symbol ()
-  "Racer uses the symbol *before* point, so make sure we move point to
-the end of the current symbol.
-
-Otherwise, if the point is halfway through HashMap, and we've
-also imported HashSet, we end up describing HashSet."
-  (let (point-during-call)
-    (cl-letf (((symbol-function 'racer--call)
-               (lambda (&rest _)
-                 (setq point-during-call (point))
-                 (list
-                  "PREFIX 36,37,n"
-                  "MATCH new;new();294;11;/home/user/src/rustc-1.10.0/src/libstd/../libcollections/vec.rs;Function;pub fn new() -> Vec<T>;\"\""
-                  "END"))))
-      (with-temp-buffer
-        (rust-mode)
-        (insert "foo();")
-        (goto-char (point-min))
-        ;; This should move point to the end of 'foo' before calling
-        ;; racer--call.
-        (racer-describe))
-      (should (equal point-during-call 4)))))
+    (with-temp-buffer
+      (rust-mode)
+      (insert "foo();")
+      (goto-char (point-min))
+      (racer-describe))))

--- a/test/racer-test.el
+++ b/test/racer-test.el
@@ -12,3 +12,185 @@
     ;; We should be at the end of foo.
     (racer--goto-func-name)
     (should (equal (point) 4))))
+
+(ert-deftest racer--read-rust-string ()
+  (should
+   (equal
+    (racer--read-rust-string "\"foo \\n \\\" \\' \\; bar")
+    "foo \n \" ' ; bar")))
+
+(ert-deftest racer--help-buf ()
+  (should
+   (bufferp
+    (racer--help-buf "Foo" "foo bar."))))
+
+(ert-deftest racer--propertize-all-inline-code ()
+  (should
+   (equal-including-properties
+    (racer--propertize-all-inline-code "foo `bar` [`baz`] biz")
+    #("foo bar baz biz" 4 7 (face font-lock-variable-name-face) 8 11 (face font-lock-variable-name-face)))))
+
+(ert-deftest racer--propertize-docstring-code ()
+  "Ensure we render code blocks with indents."
+  (should
+   (equal
+    (racer--propertize-docstring "foo
+
+```rust
+func();
+```
+
+bar.
+
+```text
+1
+2
+```
+")
+    "foo
+
+    func();
+
+bar.
+
+    1
+    2
+")))
+
+(ert-deftest racer--propertize-docstring-newlines ()
+  "Ensure we still handle links that have been split over two lines."
+  (should
+   (equal
+    (racer--propertize-docstring "[foo\nbar](baz)")
+    "foo\nbar")))
+
+(ert-deftest racer--propertize-docstring-links ()
+  "Ensure we discard footnote links."
+  (should
+   (equal
+    (racer--propertize-docstring "foo [`str`] bar
+
+[`str`]: ../../std/primitive.str.html
+
+baz.")
+    "foo str bar
+
+baz.")))
+
+(ert-deftest racer--propertize-docstring-urls ()
+  "Ensure we render buttons for links with urls."
+  (let ((result (racer--propertize-docstring "[foo](http://example.com)")))
+    (should (equal result "foo"))
+    (should (equal (get-text-property 0 'button result) '(t))))
+  (should
+   (equal-including-properties
+    (racer--propertize-docstring "[foo](#bar)")
+    "foo")))
+
+(ert-deftest racer--propertize-docstring-heading ()
+  "Ensure we render markdown headings correctly."
+  (should
+   (equal-including-properties
+    (racer--propertize-docstring "# foo")
+    #("foo" 0 3 (face racer-help-heading-face)))))
+
+(ert-deftest racer--split-parts ()
+  "Ensure we correctly parse racer CSV."
+  (should
+   (equal (racer--split-parts "foo;bar")
+          '("foo" "bar")))
+  (should
+   (equal (racer--split-parts "foo;\"bar\"")
+          '("foo" "bar")))
+  (should
+   (equal (racer--split-parts "foo\\;bar;baz")
+          '("foo;bar" "baz"))))
+
+(ert-deftest racer--describe-at-point-name ()
+  "Ensure we extract the correct name in `racer--describe-at-point'."
+  (cl-letf (((symbol-function 'racer--call)
+             (lambda (&rest _)
+               (list
+                "PREFIX 36,37,n"
+                "MATCH new;new();294;11;/home/user/src/rustc-1.10.0/src/libstd/../libcollections/vec.rs;Function;pub fn new() -> Vec<T>;\"Constructs a new, empty `Vec<T>`.\""
+                "END"))))
+    (should
+     (equal (plist-get (racer--describe-at-point) :name)
+            "new"))))
+
+(ert-deftest racer--describe-at-point-nil-docstring ()
+  "If there's no docstring, racer--describe-at-point should use nil."
+  (cl-letf (((symbol-function 'racer--call)
+             (lambda (&rest _)
+               (list
+                "PREFIX 36,37,n"
+                "MATCH new;new();294;11;/home/user/src/rustc-1.10.0/src/libstd/../libcollections/vec.rs;Function;pub fn new() -> Vec<T>;\"\""
+                "END"))))
+    (should
+     (null (plist-get (racer--describe-at-point) :docstring)))))
+
+(ert-deftest racer--describe-at-point-shortest ()
+  "If there are multiple matches, we want the shortest.
+
+Since we've moved point to the end of symbol, the other functions just happen to have the same prefix."
+  (cl-letf (((symbol-function 'racer--call)
+             (lambda (&rest _)
+               (list
+                "PREFIX 36,37,n"
+                "MATCH new;new();294;11;/home/user/src/rustc-1.10.0/src/libstd/../libcollections/vec.rs;Function;pub fn new() -> Vec<T>;\"\""
+                "MATCH new_foo;new_foo();294;11;/home/user/src/rustc-1.10.0/src/libstd/../libcollections/vec.rs;Function;pub fn new() -> Vec<T>;\"\""
+                "END"))))
+    (should
+     (equal (plist-get (racer--describe-at-point) :name)
+            "new"))))
+
+(ert-deftest racer--syntax-highlight ()
+  "Ensure we highlight code blocks and snippets correctly."
+  ;; Highlighting types should always use the type face.
+  (should
+   (equal-including-properties
+    (racer--syntax-highlight "Foo")
+    #("Foo" 0 3 (face font-lock-type-face))))
+  ;; Highlighting keywords.
+  (should
+   (equal-including-properties
+    (racer--syntax-highlight "false")
+    #("false" 0 5 (face font-lock-keyword-face))))
+  ;; Simple variables should be highlighted, even when standalone.
+  (should
+   (equal-including-properties
+    (racer--syntax-highlight "foo")
+    #("foo" 0 3 (face font-lock-variable-name-face)))))
+
+(ert-deftest racer-describe ()
+  "Smoke test for `racer-describe'."
+  (cl-letf (((symbol-function 'racer--call)
+             (lambda (&rest _)
+               (list
+                "PREFIX 36,37,n"
+                "MATCH new;new();294;11;/home/user/src/rustc-1.10.0/src/libstd/../libcollections/vec.rs;Function;pub fn new() -> Vec<T>;\"\""
+                "END"))))
+    (racer-describe)))
+
+(ert-deftest racer-describe-uses-whole-symbol ()
+  "Racer uses the symbol *before* point, so make sure we move point to
+the end of the current symbol.
+
+Otherwise, if the point is halfway through HashMap, and we've
+also imported HashSet, we end up describing HashSet."
+  (let (point-during-call)
+    (cl-letf (((symbol-function 'racer--call)
+               (lambda (&rest _)
+                 (setq point-during-call (point))
+                 (list
+                  "PREFIX 36,37,n"
+                  "MATCH new;new();294;11;/home/user/src/rustc-1.10.0/src/libstd/../libcollections/vec.rs;Function;pub fn new() -> Vec<T>;\"\""
+                  "END"))))
+      (with-temp-buffer
+        (rust-mode)
+        (insert "foo();")
+        (goto-char (point-min))
+        ;; This should move point to the end of 'foo' before calling
+        ;; racer--call.
+        (racer-describe))
+      (should (equal point-during-call 4)))))


### PR DESCRIPTION
This command fetches the docstring of the function or type at point. It
then renders the markdown in a separate buffer, so users can learn about
functionality with reading the implementation.

![racer_describe](https://cloud.githubusercontent.com/assets/70800/17954848/bf4928ae-6a4b-11e6-8a9c-77a74c16bd78.png)

Anyone willing to do a quick review? Sorry it's a big patch. cc @ane @fbergroth 