### PR TITLE
Fix column calculations when symbol rewriting is in effect

### DIFF
--- a/racer.el
+++ b/racer.el
@@ -460,17 +460,10 @@ Commands:
   (cons (get-text-property 0 'file arg)
         (get-text-property 0 'line arg)))
 
-(defun racer-get-bol-to-point ()
-  "Get text from start of line to point."
-  (let ((p (point)))
-    (save-excursion
-      (beginning-of-line)
-      (let ((bol (point)))
-        (buffer-substring-no-properties bol p)))))
-
-(defun racer-current-column ()
+(defun racer--current-column ()
   "Get the current column based on underlying character representation."
-  (string-width (racer-get-bol-to-point)))
+  (length (buffer-substring-no-properties
+           (line-beginning-position) (point))))
 
 ;;;###autoload
 (defun racer-find-definition ()

--- a/racer.el
+++ b/racer.el
@@ -112,7 +112,7 @@
     (unwind-protect
         (racer--call command
                      (number-to-string (line-number-at-pos))
-                     (number-to-string (racer-current-column))
+                     (number-to-string (racer--current-column))
                      (buffer-file-name)
                      tmp-file)
       (delete-file tmp-file))))

--- a/racer.el
+++ b/racer.el
@@ -112,7 +112,7 @@
     (unwind-protect
         (racer--call command
                      (number-to-string (line-number-at-pos))
-                     (number-to-string (current-column))
+                     (number-to-string (racer-current-column))
                      (buffer-file-name)
                      tmp-file)
       (delete-file tmp-file))))
@@ -459,6 +459,18 @@ Commands:
   "Return location of completion candidate ARG."
   (cons (get-text-property 0 'file arg)
         (get-text-property 0 'line arg)))
+
+(defun racer-get-bol-to-point ()
+  "Get text from start of line to point."
+  (let ((p (point)))
+    (save-excursion
+      (beginning-of-line)
+      (let ((bol (point)))
+        (buffer-substring-no-properties bol p)))))
+
+(defun racer-current-column ()
+  "Get the current column based on underlying character representation."
+  (string-width (racer-get-bol-to-point)))
 
 ;;;###autoload
 (defun racer-find-definition ()


### PR DESCRIPTION
Some ways of changing the displayed contents of the buffer do not play well with the current way of calculating the column offset.

For example, I wanted to use Fira Code with racer-mode. I found this trick to make firacode work:
https://gist.github.com/mordocai/50783defab3c3d1650e068b4d1c91495

The problem is that using font-lock-symbols to change the displayed symbol (replacing 2 glyphs with 1 glyph) is throwing off the column calculation in racer mode. The code in this pull request uses the string-width of the underlying string representation to calculate the column. This should match what racer sees when it parses the file.

I don't know if I applied this fix to all the places where columns are used. I could use some code review for that. Doing the calculation this way should also future proof against people using prettify-symbols-mode.

I also tried changing the character width in the char-width-table but I couldn't get that version to work. If we can make that work it's a better solution because the column information in emacs will be correct.