### PR TITLE
let `racer` locate rust sources by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,13 +65,26 @@ Use <kbd>M-x racer-describe</kbd> to open the help buffer.
 
 2. Install racer: `M-x package-install RET racer RET`
 
-3. Download the [rust sourcecode](https://www.rust-lang.org/en-US/downloads.html),
-   and configure emacs to find your rust source directory:
-   
-   ```el
-   (setq racer-rust-src-path "<path-to-rust-srcdir>/src/")
-   ```
+3. Download the Rust source code:
 
+  * If you use rustup, use it to download the rust source code in sync with the
+    current toolchain:
+
+    ```sh
+    $ rustup component add rust-src
+    ```
+    
+    No further configuration of emacs-racer is necessary, since racer looks in
+    rustup's download location by default.
+
+  * If you don't use rustup, download
+    the [rust sourcecode](https://www.rust-lang.org/en-US/downloads.html), and
+    configure emacs to find your rust source directory:
+   
+    ```el
+    (setq racer-rust-src-path "<path-to-rust-srcdir>/src/")
+    ```
+   
 4. Configure Emacs to activate racer when rust-mode starts:
    ```el
    (add-hook 'rust-mode-hook #'racer-mode)


### PR DESCRIPTION
Racer looks for Rust sources by calling `rustc --print sysroot`, if
`$RUST_SRC_PATH` is not set. This plays well with rustup's capability
to manage rust sources along with the rest of the toolchain.

To make use of this heuristic, we no longer require a source path to be
explicitly configured by the user.

fixes #54.
