### PR TITLE
Fix getting file name of indirect buffers

### DIFF
--- a/racer.el
+++ b/racer.el
@@ -112,7 +112,8 @@ If nil, we will query $CARGO_HOME at runtime."
 
 (defun racer--cargo-project-root ()
   "Find the root of the current Cargo project."
-  (let ((root (locate-dominating-file (or buffer-file-name default-directory) "Cargo.toml")))
+  (let ((root (locate-dominating-file (or (buffer-file-name (buffer-base-buffer)) default-directory)
+                                      "Cargo.toml")))
     (and root (file-truename root))))
 
 (defun racer--header (text)
@@ -251,7 +252,7 @@ Return a list of all the lines returned by the command."
       (racer--call command
                    (number-to-string (line-number-at-pos))
                    (number-to-string (racer--current-column))
-                   (buffer-file-name)
+                   (buffer-file-name (buffer-base-buffer))
                    tmp-file)))))
 
 (defun racer--read-rust-string (string)


### PR DESCRIPTION
Currently M-. does not work in an indirect cloned buffer created with C-x 4 c, as the indirect buffer does not have a file name directly. This patch gets the file name of the base buffer if the current buffer is an indirect buffer, otherwise it gets the file name of the current buffer.