### PR TITLE
Cask: add dependency declaration for "f"

### DIFF
--- a/Cask
+++ b/Cask
@@ -6,6 +6,7 @@
 (depends-on "company")
 (depends-on "dash")
 (depends-on "s")
+(depends-on "f")
 (depends-on "rust-mode")
 
 (development


### PR DESCRIPTION
Fixes racer.el obtained via El-Get if "f" isn't already installed.