### PR TITLE
Use region contents in racer-describe if active

### DIFF
--- a/racer.el
+++ b/racer.el
@@ -256,11 +256,13 @@ Return a list of all the lines returned by the command."
     (write-region nil nil tmp-file nil 'silent)
     (s-lines
      (s-trim-right
-      (racer--call command
-                   (number-to-string (line-number-at-pos))
-                   (number-to-string (racer--current-column))
-                   (buffer-file-name (buffer-base-buffer))
-                   tmp-file)))))
+      (if (region-active-p)
+          (racer--call command (buffer-substring (region-beginning) (region-end)))
+          (racer--call command
+                       (number-to-string (line-number-at-pos))
+                       (number-to-string (racer--current-column))
+                       (buffer-file-name (buffer-base-buffer))
+                       tmp-file))))))
 
 (defun racer--read-rust-string (string)
   "Convert STRING, a rust string literal, to an elisp string."


### PR DESCRIPTION
`(thing-at-point 'symbol)` ([here](https://github.com/racer-rust/emacs-racer/blob/40f99f69b46edbf0855c92d908c11e29bf2e817c/racer.el#L561)) doesn't always retrieve what we want - for instance,
when describing a namespaced fn - so we may want to check it against the active
region to work around this.