### PR TITLE
Add function to show docstrings in a tooltip

### DIFF
--- a/racer.el
+++ b/racer.el
@@ -5,7 +5,7 @@
 ;; Author: Phil Dawes
 ;; URL: https://github.com/racer-rust/emacs-racer
 ;; Version: 1.3
-;; Package-Requires: ((emacs "24.3") (rust-mode "0.2.0") (dash "2.13.0") (s "1.10.0") (f "0.18.2"))
+;; Package-Requires: ((emacs "24.3") (rust-mode "0.2.0") (dash "2.13.0") (s "1.10.0") (f "0.18.2") (pos-tip "0.4.6"))
 ;; Keywords: abbrev, convenience, matching, rust, tools
 
 ;; This file is not part of GNU Emacs.
@@ -68,6 +68,7 @@
 (require 'thingatpt)
 (require 'button)
 (require 'help-mode)
+(require 'pos-tip)
 
 (defgroup racer nil
   "Code completion, goto-definition and docs browsing for Rust via racer."
@@ -562,6 +563,24 @@ correct value."
     (if buf
         (temp-buffer-window-show buf)
       (user-error "No function or type found at point"))))
+
+(defface racer-tooltip
+  '((((min-colors 16777216))
+     :background "#292C33" :foreground "white")
+    (t
+     :background "black" :foreground "white"))
+  "Face used for the tooltip with `racer-describe-tooltip'")
+
+(defun racer-describe-tooltip ()
+  "Show the docstring in a tooltip.
+The tooltip's face is `racer-tooltip'
+See `racer-describe'."
+  (interactive)
+  (-some-> (symbol-at-point)
+           (symbol-name)
+           (racer--describe)
+           (with-current-buffer (concat "\n" (buffer-string) "\n\n"))
+           (pos-tip-show-no-propertize 'racer-tooltip nil nil 1000)))
 
 (defvar racer-help-mode-map
   (let ((map (make-sparse-keymap)))


### PR DESCRIPTION
I've written a small function to show the docstring without opening a new window:

![peek 18-11-2017 14-10](https://user-images.githubusercontent.com/5273820/32980748-a7bc6834-cc6c-11e7-856a-f2ecd3c393fc.gif)
