### PR TITLE
Insert argument placeholders for function completions

### DIFF
--- a/racer.el
+++ b/racer.el
@@ -625,7 +625,24 @@ Commands:
               :company-prefix-length (racer-complete--prefix-p beg end)
               :company-docsig #'racer-complete--docsig
               :company-doc-buffer #'racer--describe
-              :company-location #'racer-complete--location)))))
+              :company-location #'racer-complete--location
+	      :exit-function #'racer-complete--insert-args)))))
+
+(defun racer-complete--insert-args (arg &optional _finished)
+  (let ((matchtype (get-text-property 0 'matchtype arg)))
+    (if (equal matchtype "Function")
+	(let ((ctx (get-text-property 0 'ctx arg)))
+	  (let ((arguments (racer-complete--extract-args ctx)))
+	    (insert arguments)
+	    (company-template-c-like-templatify arguments)
+	    )))))
+
+(defun racer-complete--extract-args (str)
+  "Extract arguments with parentheses from STR."
+  (if (string-match "\\(([^(]+)\\)" str)
+      (let ((args (match-string 1 str)))
+	(string-match "(\\([^,]*self,?\\).*)" args)
+	(concat "("  (s-trim-left (substring args (match-end 1) (length args)))))))
 
 (defun racer--file-and-parent (path)
   "Convert /foo/bar/baz/q.txt to baz/q.txt."

--- a/racer.el
+++ b/racer.el
@@ -640,10 +640,10 @@ Commands:
 (defun racer-complete--extract-args (str)
   "Extract function arguments from STR (excluding a possible self argument)."
   (let* ((index (string-match (rx (seq "("
-					(zero-or-more (not (any "(")))
+					(zero-or-more (seq (zero-or-more (not (any "(")))
 					"self"
 					(zero-or-more space)
-					","
+					","))
 					(zero-or-more space)
 					(group (zero-or-more (not (any ")"))))
 					")")) str))

--- a/racer.el
+++ b/racer.el
@@ -639,14 +639,18 @@ Commands:
 
 (defun racer-complete--extract-args (str)
   "Extract function arguments from STR (excluding a possible self argument)."
-  (let* ((index (string-match (rx (seq "("
+  (let* ((index (string-match (rx
+			       (or (seq "("
+					(zero-or-more (not (any ",")))
+					"self)")
+				   (seq "("
 					(zero-or-more (seq (zero-or-more (not (any "(")))
 					"self"
 					(zero-or-more space)
 					","))
 					(zero-or-more space)
 					(group (zero-or-more (not (any ")"))))
-					")")) str))
+					")"))) str))
 	 (extract (match-string 1 str)))
     (if extract
 	(format "(%s)" extract)


### PR DESCRIPTION
I tried my hand at issue #37. After completion, if the matchtype was a function, it tries to extract and insert the function arguments in the same way that was referenced in the issue. If there is a `self` argument in the beginning of the argument list, that one is not inserted.

I don't know much Emacs Lisp, so please let me know if there is a mistake or something I can improve.