### PR TITLE
Fix completion when company-mode is not available

### DIFF
--- a/racer.el
+++ b/racer.el
@@ -631,14 +631,17 @@ Commands:
               :company-location #'racer-complete--location
 	      :exit-function #'racer-complete--insert-args)))))
 
+(declare-function company-template-c-like-templatify 'company-template)
+
 (defun racer-complete--insert-args (arg &optional _finished)
   "If a ARG is the name of a completed function, try to find and insert its arguments."
-  (let ((matchtype (get-text-property 0 'matchtype arg)))
-    (if (equal matchtype "Function")
-	(let* ((ctx (get-text-property 0 'ctx arg))
-	       (arguments (racer-complete--extract-args ctx)))
-	  (insert arguments)
-	  (company-template-c-like-templatify arguments)))))
+  (when (and (require 'company-template nil t)
+             (equal "Function"
+                    (get-text-property 0 'matchtype arg)))
+    (let* ((ctx (get-text-property 0 'ctx arg))
+	   (arguments (racer-complete--extract-args ctx)))
+      (insert arguments)
+      (company-template-c-like-templatify arguments))))
 
 (defun racer-complete--extract-args (str)
   "Extract function arguments from STR (excluding a possible self argument)."

--- a/racer.el
+++ b/racer.el
@@ -611,6 +611,13 @@ Commands:
   :type 'boolean
   :group 'racer)
 
+(defcustom racer-complete-insert-argument-placeholders
+  t
+  "If non-nil, insert argument placeholders after completion.
+Note that this feature is only available when `company-mode' is installed."
+  :type 'boolean
+  :group 'racer)
+
 (defun racer-complete-at-point ()
   "Complete the symbol at point."
   (let* ((ppss (syntax-ppss))
@@ -635,7 +642,8 @@ Commands:
 
 (defun racer-complete--insert-args (arg &optional _finished)
   "If a ARG is the name of a completed function, try to find and insert its arguments."
-  (when (and (require 'company-template nil t)
+  (when (and racer-complete-insert-argument-placeholders
+             (require 'company-template nil t)
              (equal "Function"
                     (get-text-property 0 'matchtype arg)))
     (let* ((ctx (get-text-property 0 'ctx arg))


### PR DESCRIPTION
`:exit-function` is actually not an `company-mode` specific thing. Other completion mechanisms may [use it as well](https://www.gnu.org/software/emacs/manual/html_node/elisp/Completion-Variables.html#index-completion_002dextra_002dproperties-1492). The first commit disables it when `company-mode` is not installed.

The second commit adds an option to turn off this feature, because I saw [this comment](https://github.com/racer-rust/emacs-racer/pull/106#issuecomment-434411463).

Thanks!