### PR TITLE
Switch to asynchronous racer command with timeouts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ Use <kbd>M-x racer-describe</kbd> to open the help buffer.
    For automatic completions, customize `company-idle-delay` and
    `company-minimum-prefix-length`.
 
+   Racer process may be slow to respond for instance when indexing. You can
+   customize `racer-command-timeout` and `racer-eldoc-timeout` to avoid rendering
+   your Emacs session unresponsive. Eldoc timeout should be on the lower side and
+   defaults to 0.5 seconds. You can probably tweak it down on a fast machine.
+   Timeout of `nil` will wait indefinitely.
+
 ### Testing your setup
 
 To test **completion**: Open a rust file and try typing ```use


### PR DESCRIPTION
This commit replaces blocking `call-process` with asynchronous `make-process`.
Instead we block explicitly until racer process output is received or timeout
fires. To that effect we introduce two new custom variables
`racer-command-timeout` and `racer-eldoc-timeout`. The latter is important because
Eldoc runs every time Emacs is idle but the user should be able to start typing
any time without waiting on the racer process. Timeout value of nil will wait for
the output indefinitely.

I observed that the first time `racer` shell process runs it may take a while to
respond probably due to indexing. Following responses tend to be snappy. For that
reason and because user asking for completion is likely ok with a bit of waiting
`racer-command-timeout` defaults to nil. `racer-eldoc-timeout` however should be
fairly low. How low depends on your machine, etc. Value of 0.1 was too short on my
machine, but 0.5 seems to work fairly reliably.

Hopefully fixes racer-rust/emacs-racer#97