### PR TITLE
Adapt racer-rust-src-path to use new rust-src dir structure

### DIFF
--- a/racer.el
+++ b/racer.el
@@ -90,7 +90,7 @@
      (let* ((sysroot (s-trim-right
                       (shell-command-to-string
                        (format "%s --print sysroot" (executable-find "rustc")))))
-            (src-path (f-join sysroot "lib/rustlib/src/rust/src")))
+            (src-path (f-join sysroot "lib/rustlib/src/rust/library")))
        (when (file-exists-p src-path)
          src-path)
        src-path))


### PR DESCRIPTION
rust/src is now rust/library on nightly and stable thus carrying that change over here as well.

More info here -> racer-rust/racer/issues/1125