### PR TITLE
fix define-obsolete-function-alias error in Emacs28

### DIFF
--- a/racer.el
+++ b/racer.el
@@ -923,8 +923,8 @@ that many seconds (maybe float)."
   (set (make-local-variable 'completion-at-point-functions) nil)
   (add-hook 'completion-at-point-functions #'racer-complete-at-point))
 
-(define-obsolete-function-alias 'racer-turn-on-eldoc 'eldoc-mode)
-(define-obsolete-function-alias 'racer-activate 'racer-mode)
+(define-obsolete-function-alias 'racer-turn-on-eldoc 'eldoc-mode "2015-08-24")
+(define-obsolete-function-alias 'racer-activate 'racer-mode "2015-08-24")
 
 (provide 'racer)
 ;;; racer.el ends here


### PR DESCRIPTION
According to HEAD NEWS, "The 'when' argument of `make-obsolete` and related functions is mandatory".